### PR TITLE
[OWL-32] Set {obj: _ , str: query} to pass jscs and jshint syntax validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+grafana
 node_modules
 coverage/
 .aws-config.json

--- a/open-falcon/server.js
+++ b/open-falcon/server.js
@@ -11,7 +11,7 @@ var request = require('request');
  * @description:	This route returns list of hosts (endpoints)
  *					 if query[0] == '*'; returns list of metrics (counters) 
  *					 otherwise.
- * @related issues:	OWL-029, OWL-017
+ * @related issues:	OWL-032, OWL-029, OWL-017
  * @param:			object req
  * @param:			object res
  * @return:			array results
@@ -27,7 +27,8 @@ app.get('/', function(req, res) {
 	var queryUrl = req.query['target'];
 	var arrQuery = req.query;
 	var query = arrQuery['query'];
-	if (query[0] === '*') {	// Query hosts, i.e., endpoints.
+
+	if (query.indexOf('*.') === 0) {	// Query hosts, i.e., endpoints.
 		query = query.replace('*.', '');
 		url = queryUrl + '/api/endpoints?q=' + query + '&tags&limit&_r=' + Math.random();
 		request(url, function (error, response, body) {

--- a/public/app/directives/metric.segment.js
+++ b/public/app/directives/metric.segment.js
@@ -76,7 +76,7 @@ function (angular, app, _, $) {
             // if (options) { return options; }
 
             $scope.$apply(function() {
-              $scope.getAltSegments({_ , str: query}).then(function(altSegments) {
+              $scope.getAltSegments({obj: _ , str: query}).then(function(altSegments) {
                 $scope.altSegments = altSegments;
                 options = _.map($scope.altSegments, function(alt) { return alt.value; });
 


### PR DESCRIPTION
```
$scope.getAltSegments({_ , str: query}) cannot pass syntax validation.
Set $scope.getAltSegments({obj: _ , str: query}) instead.

Commits:
1. Fix open-falcon/server.js to enable host name autocomplete
2. Set {obj: _ , str: query} to pass jscs and jshint syntax validation
```
