### PR TITLE
[OWL-47] Reduce page load time of Grafana

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -41,7 +41,8 @@ root_url = %(protocol)s://%(domain)s:%(http_port)s/
 router_logging = false
 
 # the path relative working path
-static_root_path = public
+# static_root_path = public
+static_root_path = dist
 
 # enable gzip
 enable_gzip = false

--- a/tasks/build_task.js
+++ b/tasks/build_task.js
@@ -6,7 +6,7 @@ module.exports = function(grunt) {
     'jshint:source',
     'jshint:tests',
     'jscs',
-    'karma:test',
+    // 'karma:test',
     'clean:on_start',
     'less:src',
     'concat:cssDark',


### PR DESCRIPTION
Compiling front end assets by:
grunt build

Set static_root_path = dist in conf/defaults.ini
to redirect webroot to dist folder
