### PR TITLE
[OWL-123] update Open-Falcon query and dashboard URL for Grafana

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -109,7 +109,8 @@ admin_user = admin
 admin_password = admin
 
 # used for signing
-secret_key = SW2YcwTIb9zpOOhoPsMm
+# secret_key = SW2YcwTIb9zpOOhoPsMm
+secret_key = e$%i7Ur#4h2yT4*&YlkN
 
 # Auto-login remember days
 login_remember_days = 7

--- a/open-falcon/server.js
+++ b/open-falcon/server.js
@@ -42,7 +42,6 @@ function getMapData(chartType)
 				if (provincesName.indexOf(key) > -1) {
 				// if (key === '内蒙古') {
 					_.forEach(province, function(city, key2) {
-						// console.log(province);
 						if (key2.length && key2 !== 'lat' && key2 !== 'lng' && key2 !== 'count') {
 							obj = {};
 							obj.name = key2;
@@ -56,7 +55,6 @@ function getMapData(chartType)
 		hosts.chartType = chartType;
 		hosts.provinces = provinces;
 		hosts.citiesInProvince = citiesInProvince;
-		// console.log('hosts =', hosts);
 		return [hosts];
 	} catch (e) {
 		console.log('Exception e =', e);
@@ -67,14 +65,14 @@ function getMapData(chartType)
 /**
  * @function name:	function function queryMetric(req, res, targets)
  * @description:	This function gets hosts locations for map chart.
- * @related issues:	OWL-030
+ * @related issues:	OWL-123, OWL-030
  * @param:			object req
  * @param:			object res
  * @param:			array targets
  * @return:			void
  * @author:			Don Hsieh
  * @since:			08/15/2015
- * @last modified: 	08/15/2015
+ * @last modified: 	10/20/2015
  * @called by:		app.post('/')
  *					 in open-falcon/server.js
  */
@@ -82,9 +80,6 @@ function queryMetric(req, res, targets)
 {
 	var metrics = [];
 	var target = '';
-	/*
-	 *	MODIFIED FOR TEMPLATING
-	 */
 	var i = 0;
 	while (i < targets.length) {	// targets.length changes dynamically
 		target = targets[i];
@@ -133,12 +128,10 @@ function queryMetric(req, res, targets)
 			from = parseInt(from) * unit;
 		}
 
-		var queryUrl = req.query['target'].split('//')[1].split(':')[0] + ':9966/graph/history';
-		queryUrl = req.query['target'].split('//')[0] + '//' + queryUrl;
-		// console.log('queryUrl =', queryUrl);
-
+		var urlQuery = req.query['urlQuery'];
+		urlQuery += '/graph/history';
 		var options = {
-			uri: queryUrl,
+			uri: urlQuery,
 			method: 'POST',
 			json: {
 				"endpoint_counters": metrics,
@@ -168,13 +161,13 @@ function queryMetric(req, res, targets)
  * @description:	This route returns list of hosts (endpoints)
  *					 if query[0] == '*'; returns list of metrics (counters)
  *					 otherwise.
- * @related issues:	OWL-063, OWL-032, OWL-029, OWL-017
+ * @related issues:	OWL-123, OWL-063, OWL-032, OWL-029, OWL-017
  * @param:			object req
  * @param:			object res
  * @return:			array results
  * @author:			Don Hsieh, WH Lin
  * @since:			07/25/2015
- * @last modified: 	08/28/2015
+ * @last modified: 	10/20/2015
  * @called by:		GET http://localhost:4001
  *					func ProxyDataSourceRequest(c *middleware.Context)
  *					 in pkg/api/dataproxy.go
@@ -183,7 +176,6 @@ app.get('/', function(req, res) {
 	var url = '';
 	var obj = {};
 	var results = [];
-	var queryUrl = req.query['target'];
 	var arrQuery = req.query;
 	var query = arrQuery['query'];
 
@@ -192,7 +184,7 @@ app.get('/', function(req, res) {
 		if ('chart'.indexOf(query) > -1) {
 			results.push({text: 'chart', expandable: true});
 		}
-		url = queryUrl + '/api/endpoints?q=' + query + '&tags&limit&_r=' + Math.random();
+		url = urlDashboard + '/api/endpoints?q=' + query + '&tags&limit&_r=' + Math.random();
 		request(url, function (error, response, body) {
 			if (!error && response.statusCode === 200) {
 				body = JSON.parse(body);
@@ -234,7 +226,7 @@ app.get('/', function(req, res) {
 			metric_q = arr.join('.');
 
 			var options = {
-				uri: queryUrl + '/api/counters',
+				uri: urlDashboard + '/api/counters',
 				method: 'POST',
 				form: {
 					"endpoints": host,
@@ -286,7 +278,6 @@ app.get('/', function(req, res) {
 							}
 						});
 					}
-					// console.log('results =', results);
 					res.send(results);
 				}
 			});

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -21,8 +21,15 @@ type DatabaseConfig struct {
 	Password   string	`json:"password"`
 }
 
+type DatasourceConfig struct {
+	Type			string	`json:"type"`
+	UrlDashboard	string	`json:"urlDashboard"`
+	UrlQuery		string	`json:"urlQuery"`
+}
+
 type GlobalConfig struct {
-	Database      *DatabaseConfig  `json:"database"`
+	Database      *DatabaseConfig    `json:"database"`
+	Datasource    *DatasourceConfig  `json:"datasource"`
 }
 
 var (
@@ -48,7 +55,6 @@ func parseConfig(cfg string) {
 	configContent, err := file.ToTrimString(cfg)
 	if err != nil {
 		l.Fatalln("read config file:", cfg, "fail:", err)
-		// log.Fatal(3, "Failed to write pidfile", err)
 	}
 
 	var configGlobal GlobalConfig
@@ -60,7 +66,6 @@ func parseConfig(cfg string) {
 	lock.Lock()
 	defer lock.Unlock()
 	configOpenFalcon = &configGlobal
-	// l.Println("read config file:", cfg, "successfully")
 }
 
 // Register adds http routes

--- a/pkg/api/dataproxy.go
+++ b/pkg/api/dataproxy.go
@@ -1,11 +1,6 @@
 package api
 
 import (
-	// "fmt"
-	// "strings"
-	// "bytes"
-	// "reflect"
-	
 	"crypto/tls"
 	"net"
 	"net/http"
@@ -29,17 +24,16 @@ var dataProxyTransport = &http.Transport{
 	TLSHandshakeTimeout: 10 * time.Second,
 }
 
-
 /**
  * @function:		func NewReverseProxy(ds *m.DataSource, proxyPath string) *httputil.ReverseProxy
  * @description:	This function initializes a reverse proxy.
- * @related issues:	OWL-028, OWL-017, OWL-002
+ * @related issues:	OWL-123, OWL-028, OWL-017, OWL-002
  * @param:			*m.DataSource ds
  * @param:			string proxyPath
  * @return:			*httputil.ReverseProxy
  * @author:			Don Hsieh
  * @since:			07/17/2015
- * @last modified: 	08/04/2015
+ * @last modified: 	10/19/2015
  * @called by:		func ProxyDataSourceRequest(c *middleware.Context)
  *					 in pkg/api/dataproxy.go
  */
@@ -63,15 +57,16 @@ func NewReverseProxy(ds *m.DataSource, proxyPath string) *httputil.ReverseProxy 
 			reqQueryVals.Add("p", ds.Password)
 			req.URL.RawQuery = reqQueryVals.Encode()
 		} else if ds.Type == "openfalcon" {
-			// fmt.Printf("Welcome to %v!\n", ds.Type)
-			// fmt.Printf("NewReverseProxy req.URL = %v\n", req.URL)
+			urlDashboard := configOpenFalcon.Datasource.UrlDashboard
+			urlQuery := configOpenFalcon.Datasource.UrlQuery
 			reqQueryVals.Add("target", ds.Url)
+			reqQueryVals.Add("urlDashboard", urlDashboard)
+			reqQueryVals.Add("urlQuery", urlQuery)
 			req.URL.RawQuery = reqQueryVals.Encode()
 
 			ds.Url = "http://localhost"
 			var port = "4001"
 			ds.Url += ":" + port
-			// fmt.Printf("NewReverseProxy ds.Url = %v\n", ds.Url)
 			proxyPath = "/"
 			target, _ := url.Parse(ds.Url)
 			req.URL.Scheme = target.Scheme
@@ -100,7 +95,6 @@ func ProxyDataSourceRequest(c *middleware.Context) {
 	}
 
 	proxyPath := c.Params("*")
-	// fmt.Printf("proxyPath = %v\n", proxyPath)
 	proxy := NewReverseProxy(&query.Result, proxyPath)
 	proxy.Transport = dataProxyTransport
 	proxy.ServeHTTP(c.RW(), c.Req.Request)

--- a/public/app/plugins/datasource/openfalcon/datasource.js
+++ b/public/app/plugins/datasource/openfalcon/datasource.js
@@ -71,7 +71,6 @@ function (angular, _, $, config, kbn, moment) {
      *                   in public/app/plugins/datasource/openfalcon/datasource.js
      */
     OpenFalconDatasource.prototype.convertDataPointsToMs = function(result) {
-      // console.log('OpenFalconDatasource.prototype.convertDataPointsToMs result.data =', result.data);
       var obj = {};
       if (!result.data.length) {
         return result;
@@ -119,17 +118,17 @@ function (angular, _, $, config, kbn, moment) {
     };
 
     OpenFalconDatasource.prototype.annotationQuery = function(annotation, rangeUnparsed) {
-      // Graphite metric as annotation
+      // Open-Falcon metric as annotation
       if (annotation.target) {
         var target = templateSrv.replace(annotation.target);
-        var graphiteQuery = {
+        var openFalconQuery = {
           range: rangeUnparsed,
           targets: [{ target: target }],
           format: 'json',
           maxDataPoints: 100
         };
 
-        return this.query(graphiteQuery)
+        return this.query(openFalconQuery)
           .then(function(result) {
             var list = [];
 
@@ -150,7 +149,7 @@ function (angular, _, $, config, kbn, moment) {
             return list;
           });
       }
-      // Graphite event as annotation
+      // Open-Falcon event as annotation
       else {
         var tags = templateSrv.replace(annotation.tags);
         return this.events({ range: rangeUnparsed, tags: tags })
@@ -173,7 +172,6 @@ function (angular, _, $, config, kbn, moment) {
     };
 
     OpenFalconDatasource.prototype.events = function(options) {
-      // console.log('OpenFalconDatasource.events options =', options);
       try {
         var tags = '';
         if (options.tags) {
@@ -212,7 +210,7 @@ function (angular, _, $, config, kbn, moment) {
         }
       }
       else if (rounding === 'round-down') {
-        // graphite' s from filter is exclusive
+        // open-falcon' s from filter is exclusive
         // here we step back one minute in order
         // to guarantee that we get all the data that
         // exists for the specified range
@@ -225,7 +223,6 @@ function (angular, _, $, config, kbn, moment) {
     };
 
     OpenFalconDatasource.prototype.metricFindQuery = function(query) {
-      // console.log('metricFindQuery query =', query);
       var interpolated;
       try {
         interpolated = encodeURIComponent(templateSrv.replace(query));
@@ -237,7 +234,6 @@ function (angular, _, $, config, kbn, moment) {
       return this.doOpenFalconRequest({method: 'GET', url: '/metrics/find/?query=' + interpolated })
         .then(function(results) {
           return _.map(results.data, function(metric) {
-            // console.log('metricFindQuery metric =', metric);
             return {
               text: metric.text,
               expandable: metric.expandable ? true : false
@@ -264,7 +260,6 @@ function (angular, _, $, config, kbn, moment) {
     };
 
     OpenFalconDatasource.prototype.doOpenFalconRequest = function(options) {
-      // console.log('OpenFalconDatasource.prototype.doOpenFalconRequest options =', options);
       if (this.basicAuth || this.withCredentials) {
         options.withCredentials = true;
       }
@@ -290,7 +285,7 @@ function (angular, _, $, config, kbn, moment) {
     ];
 
     OpenFalconDatasource.prototype.buildOpenFalconParams = function(options, scopedVars) {
-      var graphite_options = ['from', 'until', 'rawData', 'format', 'maxDataPoints', 'cacheTimeout'];
+      var openFalcon_options = ['from', 'until', 'rawData', 'format', 'maxDataPoints', 'cacheTimeout'];
       var clean_options = [], targets = {};
       var target, targetValue, i;
       var regex = /(\#[A-Z])/g;
@@ -333,7 +328,7 @@ function (angular, _, $, config, kbn, moment) {
       }
 
       _.each(options, function (value, key) {
-        if ($.inArray(key, graphite_options) === -1) { return; }
+        if ($.inArray(key, openFalcon_options) === -1) { return; }
         if (value) {
           clean_options.push(key + "=" + encodeURIComponent(value));
         }

--- a/public/app/plugins/datasource/openfalcon/queryCtrl.js
+++ b/public/app/plugins/datasource/openfalcon/queryCtrl.js
@@ -50,7 +50,7 @@ function (angular, _, config, gfunc, Parser) {
       }
 
       try {
-        parseTargeRecursive(astNode);
+        parseTargetRecursive(astNode);
       }
       catch (err) {
         $scope.parserError = err.message;
@@ -67,7 +67,7 @@ function (angular, _, config, gfunc, Parser) {
       func.params[index] = value;
     }
 
-    function parseTargeRecursive(astNode, func, index) {
+    function parseTargetRecursive(astNode, func, index) {
       if (astNode === null) {
         return null;
       }
@@ -77,7 +77,7 @@ function (angular, _, config, gfunc, Parser) {
         var innerFunc = gfunc.createFuncInstance(astNode.name, { withDefaultParams: false });
 
         _.each(astNode.params, function(param, index) {
-          parseTargeRecursive(param, innerFunc, index);
+          parseTargetRecursive(param, innerFunc, index);
         });
 
         innerFunc.updateText();


### PR DESCRIPTION
update cfg.json
{
    "database": {
        "addr": "10.20.30.40:3306",
        "account": "root",
        "password": "password"
    },
    "datasource": {
        "type": "Open-Falcon",
        "urlDashboard": "http://dashboard.owlemon.com:8081",
        "urlQuery": "http://graph.owlemon.com:9966"
    }
}

pkg/api/api.go
add
type DatasourceConfig struct {
    Type            string  `json:"type"`
    UrlDashboard    string  `json:"urlDashboard"`
    UrlQuery        string  `json:"urlQuery"`
}

pkg/api/dataproxy.go
func NewReverseProxy(ds *m.DataSource, proxyPath string) *httputil.ReverseProxy
add
urlDashboard := configOpenFalcon.Datasource.UrlDashboard
urlQuery := configOpenFalcon.Datasource.UrlQuery
reqQueryVals.Add("urlDashboard", urlDashboard)
reqQueryVals.Add("urlQuery", urlQuery)

open-falcon/server.js
function queryMetric(req, res, targets)
add
var urlQuery = req.query['urlQuery'];
urlQuery += '/graph/history';

app.get('/', function(req, res)
add
var urlDashboard = req.query['urlDashboard'];
